### PR TITLE
Fix typespecs and iodata conversion

### DIFF
--- a/src/seestar_messages.erl
+++ b/src/seestar_messages.erl
@@ -48,7 +48,10 @@
                   | #'query'{}
                   | #prepare{}
                   | #execute{}
-                  | #register{}.
+                  | #register{}
+                  | #batch{}
+                  | #batch_query{}
+                  | #batch_execute{}.
 
 -type incoming() :: #error{}
                   | #ready{}


### PR DESCRIPTION
- `outgoing()` type is now up to date
- Fixed query conversion to binary
